### PR TITLE
Update gpx-viewer runtime to 46

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,48 @@
+diff --git a/data/gpx-viewer.metainfo.xml b/data/gpx-viewer.metainfo.xml
+index f6335ca..fabc622 100644
+--- a/data/gpx-viewer.metainfo.xml
++++ b/data/gpx-viewer.metainfo.xml
+@@ -98,37 +98,13 @@
+     <binary>gpx-viewer</binary>
+   </provides>
+ 
+-  <launchable type="desktop-id">gpx-viewer.desktop</launchable>
++  <launchable type="desktop-id">nl.sarine.gpx-viewer.desktop</launchable>
+   <url type="homepage">https://blog.sarine.nl/tag/gpxviewer/</url>
+   <url type="bugtracker">https://github.com/DaveDavenport/gpx-viewer/issues</url>
++  <url type="vcs-browser">https://github.com/DaveDavenport/gpx-viewer</url>
++  <developer id="nl.sarine">
++    <name>Dave Davenport</name>
++  </developer>
+ 
+-  <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
++  <content_rating type="oars-1.1" />
+ </component>

--- a/nl.sarine.gpx-viewer.json
+++ b/nl.sarine.gpx-viewer.json
@@ -1,12 +1,13 @@
 {
     "app-id" : "nl.sarine.gpx-viewer",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "gpx-viewer",
     "rename-desktop-file" : "gpx-viewer.desktop",
     "rename-appdata-file" : "gpx-viewer.metainfo.xml",
     "rename-icon" : "gpx-viewer",
+    "copy-icon": true,
     "finish-args" : [
         "--share=ipc",
         "--socket=fallback-x11",
@@ -18,17 +19,19 @@
     "cleanup" : [
         "/include",
         "/lib/pkgconfig",
-        "/share/pkgconfig",
-        "/share/aclocal",
         "/man",
-        "/share/man",
+        "/share/aclocal",
+        "/share/gir-1.0",
         "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
         "/share/vala",
         "*.la",
         "*.a"
     ],
     "modules" : [
         "shared-modules/clutter/clutter.json",
+        "shared-modules/libsoup/libsoup-2.4.json",
         {
             "name": "libchamplain",
             "buildsystem": "meson",
@@ -71,6 +74,10 @@
                     "type" : "git",
                     "url" : "https://github.com/DaveDavenport/gpx-viewer",
                     "tag" : "0.5.0"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fix_appdata.patch"
                 }
             ]
         }


### PR DESCRIPTION
- runtime: Update runtime to 46
- appdata: Fix appdata related issues
- app: Fix missing icon on about dialog
- flatpak: better clean up to reduce the file size